### PR TITLE
remove trailing comma for IE7

### DIFF
--- a/raphael.json.js
+++ b/raphael.json.js
@@ -18,7 +18,7 @@
 				type:      el.type,
 				attrs:     el.attrs,
 				transform: el.matrix.toTransformString(),
-				node:      { id: el.node.id },
+				node:      { id: el.node.id }
 				});
 		}
 


### PR DESCRIPTION
sorry I didn't catch this with my last comma-related pull request
