### PR TITLE
Element filtering

### DIFF
--- a/raphael.json.js
+++ b/raphael.json.js
@@ -15,13 +15,13 @@
 
 		for ( var el = paper.bottom; el != null; el = el.next ) {
 
-            if ( filter === "undefined" || filter(el) ) {
-    			elements.push({
-    				type:      el.type,
-    				attrs:     el.attrs,
-    				transform: el.matrix.toTransformString(),
-    				node:      { id: el.node.id }
-    				});
+			if ( filter === "undefined" || filter(el) ) {
+				elements.push({
+					type:      el.type,
+					attrs:     el.attrs,
+					transform: el.matrix.toTransformString(),
+					node:      { id: el.node.id }
+				});
 			}
 		}
 

--- a/raphael.json.js
+++ b/raphael.json.js
@@ -8,18 +8,21 @@
  */
 
 (function() {
-	Raphael.fn.toJSON = function() {
+	Raphael.fn.toJSON = function(filter) {
 		var paper = this;
 
 		var elements = new Array;
 
 		for ( var el = paper.bottom; el != null; el = el.next ) {
-			elements.push({
-				type:      el.type,
-				attrs:     el.attrs,
-				transform: el.matrix.toTransformString(),
-				node:      { id: el.node.id }
-				});
+
+            if ( filter === "undefined" || filter(el) ) {
+    			elements.push({
+    				type:      el.type,
+    				attrs:     el.attrs,
+    				transform: el.matrix.toTransformString(),
+    				node:      { id: el.node.id }
+    				});
+			}
 		}
 
 		return JSON.stringify(elements);


### PR DESCRIPTION
Enables optional filtering of the serialised JSON elements. An example use case is when serialising elements with Raphael.FreeTransform applied - you may not want to serialise the FT handles etc. in which case you could check if the element itself had a 'freeTransform' property (in which case allow it to be serialised by returning true from the filter function).

Trivial example:

``` javascript

var paper = Raphael(0, 0, 400, 400);

var circle = paper.circle(50, 50, 50).attr('fill', '#0f0');

var filter = function (el) {
    return el.type === "circle"; // Only allow 'circles' to be serialised
};

paper.toJSON(filter);
```
