### PR TITLE
Allow filtering elements in callback in `toJSON`

### DIFF
--- a/raphael.json.js
+++ b/raphael.json.js
@@ -15,7 +15,7 @@
 		for ( var el = paper.bottom; el != null; el = el.next ) {
 			data = callback ? callback(el, new Object) : new Object;
 
-			elements.push({
+			if ( data ) elements.push({
 				data:      data,
 				type:      el.type,
 				attrs:     el.attrs,


### PR DESCRIPTION
This was useful for me (for filtering out elements hidden with `hide()`). Haven't thought too much about any drawbacks.
