### PR TITLE
Remove a trailing comma

### DIFF
--- a/raphael.json.js
+++ b/raphael.json.js
@@ -19,7 +19,7 @@
 				data:      data,
 				type:      el.type,
 				attrs:     el.attrs,
-				transform: el.matrix.toTransformString(),
+				transform: el.matrix.toTransformString()
 				});
 		}
 


### PR DESCRIPTION
Currently breaks in IE6 and IE7, this pull request removes it to make it work.
